### PR TITLE
terraform-hotfix

### DIFF
--- a/terraform04/demonstration1/main.tf
+++ b/terraform04/demonstration1/main.tf
@@ -2,31 +2,35 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.13"
+    }
+    template = {
+      source = "hashicorp/template"
+      version = ">=2.0"
     }
   }
   required_version = ">=0.13"
 
   backend "s3" {
-  endpoint = "storage.yandexcloud.net"
-  bucket   = "tfstate-develop-42"
-  region   = "ru-central1"
-  key      = "terraform.tfstate"
+    endpoint = "storage.yandexcloud.net"
+    bucket   = "tfstate-develop-42"
+    region   = "ru-central1"
+    key      = "terraform.tfstate"
 
-  skip_region_validation      = true
-  skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_credentials_validation = true
 
-  dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1g1nmcaed0kbughlnoh/etn0of5p4rua2dsfk5jr"
-  dynamodb_table    = "tflock-develop"
+    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1g1nmcaed0kbughlnoh/etn0of5p4rua2dsfk5jr"
+    dynamodb_table    = "tflock-develop"
+  }
+
 }
-
-}
-
-provider "yandex" {
-  token     = var.token
-  cloud_id  = var.cloud_id
-  folder_id = var.folder_id
-  zone      = var.default_zone
-}
+  provider "yandex" {
+    token     = var.token
+    cloud_id  = var.cloud_id
+    folder_id = var.folder_id
+    zone      = var.default_zone
+  }
 
 
 
@@ -44,7 +48,7 @@ resource "yandex_vpc_subnet" "develop" {
 }
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=test"
   env_name        = "develop"
   network_id      = yandex_vpc_network.develop.id
   subnet_zones    = ["ru-central1-a"]
@@ -52,7 +56,8 @@ module "test-vm" {
   instance_name   = "web"
   instance_count  = 2
   image_family    = "ubuntu-2004-lts"
-  public_ip       = true
+  public_ip       = false
+  security_group_ids = ["enp63ruhhg5u9uv1pu22"]
   
   metadata = {
       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3

--- a/terraform04/demonstration1/variables.tf
+++ b/terraform04/demonstration1/variables.tf
@@ -19,19 +19,6 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
 
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
 
-variable "public_key" {
-  type    = string
-  default = ""
-}
+


### PR DESCRIPTION
tflint analysis:

6 issue(s) found:

Warning: Missing version constraint for provider "yandex" in "required_providers" (terraform_required_providers)

  on main.tf line 39:
  39: resource "yandex_vpc_subnet" "develop" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 47:
  47:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)

  on main.tf line 65:
  65: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md

Warning: variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 28:
  28: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

Warning: variable "public_key" is declared but not used (terraform_unused_declarations)

  on variables.tf line 34:
  34: variable "public_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_unused_declarations.md

checkov analysis:

Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.test-vm.yandex_compute_instance.vm
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/main/main.tf:24-73
        Calling File: /main.tf:46-62
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.test-vm.yandex_compute_instance.vm
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/main/main.tf:24-73
        Calling File: /main.tf:46-62

terraform plan changes:

Terraform will perform the following actions:

  # module.test-vm.null_resource.example will be created
  + resource "null_resource" "example" {
      + id = (known after apply)
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhm6b8jaqdfrntcfgsj7"
        name                      = "develop-web-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [
              + "enp63ruhhg5u9uv1pu22",
            ]
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.test-vm.yandex_compute_instance.vm[1] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmr2ncoqoqcl22n59e0"
        name                      = "develop-web-1"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
          ~ security_group_ids = [
              + "enp63ruhhg5u9uv1pu22",
            ]
            # (8 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 1 to add, 2 to change, 0 to destroy.

